### PR TITLE
Fix pod error in Utils.pm

### DIFF
--- a/lib/CAPE/Utils.pm
+++ b/lib/CAPE/Utils.pm
@@ -1542,7 +1542,7 @@ L<https://rt.cpan.org/NoAuth/Bugs.html?Dist=CAPE-Utils>
 
 L<https://metacpan.org/release/CAPE-Utils>
 
-=head * Git
+=item * Git
 
 L<git@github.com:VVelox/CAPE-Utils.git>
 


### PR DESCRIPTION
In a list there was "=head * Git" where it should be "=item * Git". This commit fixes this.